### PR TITLE
support for Ulauncher API version 2

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,5 @@
 {
-  "manifest_version": "1",
-  "api_version": "1",
+  "required_api_version": "^2.0.0",
   "name": "System Management",
   "description": "Suspend / Hibernate / Reboot / Shutdown functions using systemd System and Service Manager.",
   "developer_name": "Roberto Leinardi",

--- a/versions.json
+++ b/versions.json
@@ -1,0 +1,4 @@
+[
+  { "required_api_version": "^1.0.0", "commit": "python2" },
+  { "required_api_version": "^2.0.0", "commit": "master" }
+]


### PR DESCRIPTION
Adds support for Ulauncher API version 2 (introduced with Ulauncher v5). Important: create `python2` branch from existing (pre-migration) code first! See http://docs.ulauncher.io/en/latest/extensions/migration.html#migrate-from-api-v1-to-v2-0-0